### PR TITLE
feat: Add basic repo to wrap dbcontext and adding connection string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 **/packages/*
 
 
+/UserAuthenticationSystem/appsettings.json

--- a/UserAuthenticationSystem/Repositories/IUserRepo.cs
+++ b/UserAuthenticationSystem/Repositories/IUserRepo.cs
@@ -1,0 +1,6 @@
+﻿namespace UserAuthenticationSystem.Repositories
+{
+    public interface IUserRepo
+    {
+    }
+}

--- a/UserAuthenticationSystem/Repositories/UserRepo.cs
+++ b/UserAuthenticationSystem/Repositories/UserRepo.cs
@@ -1,0 +1,6 @@
+﻿namespace UserAuthenticationSystem.Repositories
+{
+    public class UserRepo
+    {
+    }
+}

--- a/UserAuthenticationSystem/appsettings.json
+++ b/UserAuthenticationSystem/appsettings.json
@@ -1,9 +1,0 @@
-{
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
-  },
-  "AllowedHosts": "*"
-}


### PR DESCRIPTION
## What?
*  I've added initial user repository and related interface.
*  I've added connection string to appsettings.json and ignored that file.
## Why?
*  These files will be the base when dealing with database.
## How?
*  I've added UserRepo, IUserRepo for dependency injection and loosely coupling.
*  Added connection string to appsettings.json file and read it using builder.Configuration.GetConnectionString()
## Testing?
*  Not yet!
## Anything Else?
-  I will further develop on this basic repo, adding basic authentication features, so I need to add associated controllers, viewModels, related service for basic authentication and develop this repo even further!